### PR TITLE
Fix: Contract compile and test

### DIFF
--- a/packages/hardhat-ts/contracts/GeoNFT.sol
+++ b/packages/hardhat-ts/contracts/GeoNFT.sol
@@ -116,9 +116,10 @@ contract GeoNFT is
     function _beforeTokenTransfer(
         address from,
         address to,
-        uint256 tokenId
+        uint256 tokenId,
+        uint256 batchSize
     ) internal override(ERC721, ERC721Enumerable) {
-        super._beforeTokenTransfer(from, to, tokenId);
+        super._beforeTokenTransfer(from, to, tokenId, batchSize);
     }
 
     function _burn(uint256 tokenId)

--- a/packages/hardhat-ts/test/GeoNFT.test.ts
+++ b/packages/hardhat-ts/test/GeoNFT.test.ts
@@ -269,7 +269,7 @@ describe("geonft", () => {
         .withArgs(ZERO_ADDRESS, other.address, tokenId);
 
       await expect(geonft.burn(tokenId)).to.be.revertedWith(
-        "ERC721: caller is not token owner nor approved'"
+        "ERC721: caller is not token owner or approved'"
       );
 
       expect(await geonft.balanceOf(other.address)).to.equal(1);


### PR DESCRIPTION
fixes two small issues that prevent the hardhat tests to run successfully:
- a missing parameter in the _beforeTokenTransfer hook
- a type in the test file for a revert message